### PR TITLE
Fixing MD typos & Some presentation inconsistencies

### DIFF
--- a/Act I - Into the Mists/Arc A - Escape From Death House.md
+++ b/Act I - Into the Mists/Arc A - Escape From Death House.md
@@ -554,7 +554,7 @@ This room is largely as described in **Children’s Room** (p. 215-16).
 > ***Inspirations.*** When playing Thorn, channel Neville Longbottom (*Harry Potter*) and Piglet (*Winnie the Pooh*).
 >
 > **Character Information**
-***Persona.*** To the world, Thorn is a frightened young boy who clings to his sister. To those he trusts, Thorn is  a quietly observant and insightful child.
+> ***Persona.*** To the world, Thorn is a frightened young boy who clings to his sister. To those he trusts, Thorn is  a quietly observant and insightful child.
 >
 > ***Morale.*** In a fight, Thorn would cower and cry, pleading for Rose to rescue him.
 >

--- a/Act I - Into the Mists/Arc C - Into the Valley.md
+++ b/Act I - Into the Mists/Arc C - Into the Valley.md
@@ -483,7 +483,7 @@ After one of the players has gone, Eliza then shares the following tale:
 <p>“Sing, ravens, of Chernovog’s rise, named Green-God and Demon-Lord upon Yester Hill. Lugdana, gray-haired, weary of battle, her longsword and shield yet polished and ready. Guided through shadows, toward sacred ground, she clashed with the demon, their tempest-like dance.</p>
 <p>“Sing, ravens, of Lugdana’s last fury, of Ravenkind’s token now blazing with light. The battle’s tide turning, a hero’s brave cry, a final onslaught with divinity’s grace. The Demon-Lord banished, the warrior now fell, the wound at her side gouged too deep to bear.</p>
 <p>“Sing, ravens, of light’s final moments, a shadow descending from radiance on high. Sing of the angel, black-feathered and beaked, the Morninglord’s angel reclaiming its gift. The Symbol retaken, in ravens’ claws held.</p>
-<p>“Sing, ravens; you are the keepers, the watchers, the tellers of stories untold. Sing, ravens, of Lugdana’s memory, the shadows that lurk, and heroes to come.”</p></div> 
+<p>“Sing, ravens; you are the keepers, the watchers, the tellers of stories untold. Sing, ravens, of Lugdana’s memory, the shadows that lurk, and heroes to come.”</p></div>
 
 When her tale has ended and all participants have made their guesses—Stanimir and Arturi going last, with Stanimir voting “True” and Arturi voting “False”—Eliza reveals that her story was half-true. 
 

--- a/Act II - The Shadowed Town/Arc F - Lady Wachter's Wish.md
+++ b/Act II - The Shadowed Town/Arc F - Lady Wachter's Wish.md
@@ -24,7 +24,7 @@ Urwin doesn’t know who the letter is from, but can tell the players that it wa
 
 The envelope contains the following letter, with the blank filled with the name of whichever player the envelope was addressed to:
 
-<div class="sidebar">
+<div class="description">
 <p>Dear _____ and esteemed companions,</p>
 <p>I hope this missive finds you in good health and high spirits. Vallaki appears to have been blessed by your presence and the promise of goodwill you bear with you.</p>
 <p>It has come to my attention that our paths, though they wind through such trying times, bear a striking convergence. Accordingly, I write to you today with a humble invitation to dine at my home, Wachterhaus, at sundown tomorrow evening. You may find it on Vallaki’s northern road, a short distance from the Zarovich Gate.</p>

--- a/Act III - The Broken Land/Arc P - Ravenloft Heist.md
+++ b/Act III - The Broken Land/Arc P - Ravenloft Heist.md
@@ -1262,8 +1262,7 @@ This area is largely as described in <span class="citation">K67. Hall of Bones (
 
 For the next 1 minute, an additional **skeleton** crawls from each non-destroyed bone mound at initiative count 0 of each round. Each bone mound has AC 15, 10 hit points, immunity to piercing, psychic, and poison damage, and vulnerability to bludgeoning damage.
 
-> [!lore]+ The Hall of Bones
-> 
+> [!lore]+ **The Hall of Bones**
 > Over a century ago, Volenta transformed the mess hall into an elaborate ossuary as an art piece signifying her devotion to Strahd.
 
 > [!abstract]+ **Storing the Skull**

--- a/Act IV - Secrets of the Ancient/Arc S - A Sword of Sunlight.md
+++ b/Act IV - Secrets of the Ancient/Arc S - A Sword of Sunlight.md
@@ -490,7 +490,7 @@ Dorina’s **ghost** still haunts this room from the Ethereal Plane, and has the
 Once she emerges, Dorina immediately attempts to use her ***possession*** to possess a member of the party, preferring to target a player that has already noticed her. If her attempt fails, she sullenly drifts back into the floor, her teeth bared in a defiant snarl.
 
 > [!abstract]+ **Dorina’s Unfinished Business**
-If Dorina successfully possesses a character, she pretends to be that character but slips away at the first opportunity. If she does so successfully, or if confronted, she attempts to reach Khirad’s sarcophagus in <span class="citation">X33c. Ghastly Vault (p. 192)</span>. 
+> If Dorina successfully possesses a character, she pretends to be that character but slips away at the first opportunity. If she does so successfully, or if confronted, she attempts to reach Khirad’s sarcophagus in <span class="citation">X33c. Ghastly Vault (p. 192)</span>. 
 >
 > Unless prevented from doing so, Dorina (in the player’s body) then accepts the *dark gift of Khirad* and asks the vestige a single question: “How can Barovia be escaped?" A possessed player hears Khirad’s whispered reply: *When the stars align, and the veil grows thin, the door you seek shall be laid open.*
 >
@@ -518,7 +518,7 @@ This area is largely as described in <span class="citation">X31. Central Catacom
 </div>
 
 > [!info]+ **The Slaad**
-On the night before the players’ arrival at the Amber Temple, a **death slaad** named Nardag came upon a cloud of mist drifting through the plane of Limbo. Intrigued, and sensing the evil of the Dark Powers through the mist, the death slaad eagerly leapt into the mist, whereupon it was spirited away to the Amber Temple in Barovia, where the boundary between worlds was weakest.
+> On the night before the players’ arrival at the Amber Temple, a **death slaad** named Nardag came upon a cloud of mist drifting through the plane of Limbo. Intrigued, and sensing the evil of the Dark Powers through the mist, the death slaad eagerly leapt into the mist, whereupon it was spirited away to the Amber Temple in Barovia, where the boundary between worlds was weakest.
 >
 > After initially appearing in <span class="citation">X8. Upper East Hall (p. 185)</span>, Nardag sensed Neferon’s presence and immediately attacked. Ultimately, after fleeing Nardag’s attack, Neferon lured the slaad into the catacombs and sealed it there.
 >

--- a/Chapter 3 - Running the Game/Adventure Summary.md
+++ b/Chapter 3 - Running the Game/Adventure Summary.md
@@ -7,7 +7,8 @@
     </ol>
 
 # Act I: Into the Mists
-<div class="subtitle"><em>For 2nd to 3rd-level characters.</em></div>
+_For 2nd to 3rd-level characters._
+
 In this act, the players are lured into the haunted Death House, which mystically transports them into the land of Barovia. As the players gain their bearings, they travel to the village of Barovia, where they meet burgomaster Ismark Kolyanovich and his sister, Ireena Kolyana, and learn about the mysterious Strahd von Zarovich, a vampire that has recently awoken to plague the Barovian valley. 
 
 The players are asked to escort Ireena to the nearby town of Vallaki for safety; if the players agree, Ireena also asks them to assist in the burial of her late father, Burgomaster Kolyan Indirovich. While at the local church, the players meet Doru, a **vampire spawn** at war with his bloodthirsty nature, and have an opportunity to reconcile him with his father, the priest Donavich.
@@ -30,7 +31,8 @@ Upon their arrival in Vallaki, the players can find shelter at the Blue Water In
 |   3   | C   | The players escort Ireena to Vallaki                               | 250   |
 
 # Act II: The Shadowed Town
-<div class="subtitle"><em>For characters of 4th level and higher.</em></div>
+_For characters of 4th level and higher._
+
 In this act, the players are left to explore the shadowed town of Vallaki—a Barovian settlement that has fallen to tension and conflict in the wake of Strahd's awakening.
 
 As the players seek to complete lingering obligations—escorting Ireena to St. Andral's Church, purchasing and delivering a toy for the Vistani child Arabelle, and uncovering the *Tome of Strahd*—they meet new allies and enemies, including Father Lucian, the priest of St. Andral's Church; Izek Strazni, Baron Vallakovich's brutal enforcer; and Lady Fiona Wachter, the Baron's Strahd-loyalist rival.
@@ -53,7 +55,7 @@ Act II ends on the morning after the players' first full moon in Barovia, which 
 |   5   | H     | The players obtain the *Tome of Strahd*                  |       |
 
 # Act III: The Broken Land
-<div class="subtitle"><em>For characters of 5th level and higher.</em></div>
+_For characters of 5th level and higher._
 
 In this act, the players receive a plea from Urwin Martikov to investigate the Wizard of Wines winery—and an invitation from Strahd to dine at Castle Ravenloft.
 
@@ -93,7 +95,7 @@ Act III ends when the players recruit the dusk elf Kasimir to journey to the Amb
 |       7        | Q   | The players light Argynvost's beacon                                                         | 3,000 |
 
 # Act IV: Secrets of the Ancient
-<div class="subtitle"><em>For characters of 8th level and higher.</em></div>
+_For characters of 8th level and higher._
 
 Throughout this act, and until the players light the *Sunsword*, Strahd—having now assumed his [[Strahd von Zarovich#The Tyrant|Tyrant persona]] following the players' heist of Castle Ravenloft—appears nightly to torment them in [[Arc R - Trials of the Mountain]], seeking to test their ambition, cunning, power, and capacity for cruelty.
 
@@ -107,7 +109,8 @@ When the players have recovered the broken hilt of the *Sunsword*, they learn th
 
 In [[Arc V - The Ladies of the Fanes]], the players must use the three enchanted gems of the Wizard of Wines winery and three ancient artifacts retrieved from the Gulthias Tree of Yester Hill to reconsecrate the three Fanes, even as Strahd musters his forces to defeat them. Act IV ends when the players reconsecrate all three Fanes.
 # Act V: The Curse of Strahd
-<div class="subtitle"><em>For characters of 9th level and higher.</em></div>
+_For characters of 9th level and higher._
+
 In this act, soon after the last Fane is restored, Strahd's masterstroke unfolds. By releasing the stored energy bound within the Heart of Sorrow, Strahd plunges Barovia into an eternal night—and turns the valley itself into desecrated ground. Meanwhile, the Whispering Wall—resonating with the energies of the Heart of Sorrow—relocates to the surface of Lake Zarovich, where its deadly tendrils threaten to extinguish all life in Vallaki in [[Arc W - Forgotten Dreams]].
 
 Even once the Whispering Wall is quelled, however, a greater danger emerges in [[Arc X - The Curse of Strahd]]. As an undead apocalypse threatens to overwhelm the Barovian people, the players must journey to Castle Ravenloft to face Strahd at the Heart of Sorrow. As the final battle unfolds, the Heart of Sorrow shows visions of Strahd's undead siege from across Barovia—and of the heroic resistance shown by the allies and friends that the players have made across their journey:
@@ -121,6 +124,5 @@ Even once the Whispering Wall is quelled, however, a greater danger emerges in [
 ***Wizard of Wines.*** If the players saved the Wizard of Wines from the druids and Wintersplinter, defeated Baba Lysaga, and relit the beacon of Argynvostholt, the winery is saved by the combined efforts of the Keepers of the Feather and the spirits of the Order of the Silver Dragon.
 
 ***Settlement of Soldav.*** If the players aided the Mountain Folk within the Amber Temple and reconsecrated the Fanes of Barovia, the settlement of Soldav is saved by the sudden arrival of the Mountain Folk warrior Helwa, the chieftain Kavan and his warband of spirits, the bestial spirits of the Huntress, and the **roc** of Mount Ghakis itself.
-<div style="height: 1px;"></div>
 
 Should the players defeat Strahd, the Mists vanish and the sun rises over Barovia once again—a free land, at long last.

--- a/Chapter 3 - Running the Game/Running the Adventure.md
+++ b/Chapter 3 - Running the Game/Running the Adventure.md
@@ -59,15 +59,18 @@ The contents of the Tome of Strahd are now as described in [[Arc H - The Lost So
 ## The Holy Symbol of Ravenkind
 The *Holy Symbol of Ravenkind* has been revised as follows:
 
-<div class="item">
-<h3>Holy Symbol of Ravenkind</h3>
-<div class="subtitle"><em>Wondrous item, legendary (requires attunement by a creature of good alignment)</em></div>
-<p>The holy symbol has 5 charges for the following properties. It regains 1d4 + 1 charges daily at dawn.</p>
-<p><strong><em>Dawn's Embrace.</em></strong> As a reaction, when a creature you can see within 60 feet of you would be reduced to 0 hit points, you can expend 1 charge to cause that creature to drop to 1 hit point instead. That creature gains immunity to all damage until the start of its next turn.</p>
-<p><strong><em>Light of Hope.</em></strong> As an action, you can expend 1 charge and choose one creature you can see within 30 feet of you. All of the following conditions on that creature end: blinded, charmed, deafened, frightened, paralyzed, poisoned, and stunned.</p>
-<p><strong><em>Sun’s Blessing.</em></strong> As an action, you can expend 3 charges to cause holy power to radiate from the symbol in a 30-foot radius for 1 minute. Nonhostile creatures in that radius deal an extra 1d4 radiant damage when they hit with a weapon attack.</p>
-<p>You can also use the holy symbol as a spellcasting focus for your cleric and paladin spells. You gain a +1 bonus to spell attack rolls and to the saving throw DCs of your cleric and paladin spells.</p>
-</div>
+> [!item]+ **Holy Symbol of Ravenkind**
+> _Wondrous item, legendary (requires attunement by a creature of good alignment)_
+>
+> The holy symbol has 5 charges for the following properties. It regains 1d4 + 1 charges daily at dawn.
+>
+> **_Dawn's Embrace._** As a reaction, when a creature you can see within 60 feet of you would be reduced to 0 hit points, you can expend 1 charge to cause that creature to drop to 1 hit point instead. That creature gains immunity to all damage until the start of its next turn.
+> 
+> **_Light of Hope._** As an action, you can expend 1 charge and choose one creature you can see within 30 feet of you. All of the following conditions on that creature end: blinded, charmed, deafened, frightened, paralyzed, poisoned, and stunned.
+> 
+> **_Sun’s Blessing._** As an action, you can expend 3 charges to cause holy power to radiate from the symbol in a 30-foot radius for 1 minute. Nonhostile creatures in that radius deal an extra 1d4 radiant damage when they hit with a weapon attack.
+> 
+> You can also use the holy symbol as a spellcasting focus for your cleric and paladin spells. You gain a +1 bonus to spell attack rolls and to the saving throw DCs of your cleric and paladin spells.
 
 ## The Sunsword
 The *Sunsword* cannot be attuned when the players first obtain it. Instead, the players must submerge it in the blessed pool near the Shrine of the White Sun to restore its radiant blade. (The hilt retains its sentience and ability to communicate telepathically before its blade is restored.) For more information about this arc, see ***Arc V: The Sunsword*** below.


### PR DESCRIPTION
Fixing more stuff disregarded by obsidian :
- `>` missing in some callouts
- Removed initial newline in callout, messing up the title
- changed `sidebar` to `description` as it uses the same layout
- For consistency, removed the `<div class="subtitle"></div>` in favor of `**__**`
- Switched the Holy Symbol of Ravenkind to an item callout